### PR TITLE
Check for existing attributes in Sziplus.isrealnode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name='sastadev',
-    version='0.2.3',
+    version='0.2.4',
     description='Linguistic functions for SASTA tool',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/sastadev/Sziplus.py
+++ b/src/sastadev/Sziplus.py
@@ -98,11 +98,11 @@ def isrealnode(node: SynTree) -> bool:
     '''
     pt = getattval(node, 'pt')
     rel = getattval(node, 'rel')
-    if pt == 'let':
+    if pt and pt == 'let':
         result = False
     elif isvcinforppart(node):
         result = False
-    elif rel == 'svp' and pt in node.attrib:
+    elif (rel and rel == 'svp') and (pt and pt in node.attrib):
         result = False
     elif isindexnode(node):
         result = False

--- a/tests/Sziplus_test.py
+++ b/tests/Sziplus_test.py
@@ -1,6 +1,6 @@
 from lxml import etree
 
-from sastadev.Sziplus import empty, notempty, sziplus6
+from sastadev.Sziplus import empty, isrealnode, notempty, sziplus6
 
 testtree1str = '''  <alpino_ds version="1.3" id="Treebank_Schlichting_CHAT-115.xml">
     <node begin="0" cat="top" end="8" id="0" rel="top">
@@ -217,3 +217,12 @@ def test_sziplus():
     assert report(test4, notempty)
     test5 = sziplus6(testtree5)
     assert report(test5, empty)
+
+
+def test_isrealnode():
+    attrib = {'begin': '180', 'cat': 'mwu', 'end': '191', 'id': '31',
+              'mwu_root': 'naar buiten', 'mwu_sense': 'naar buiten', 'rel': 'svp'}
+
+    node = etree.Element('node', attrib=attrib)
+
+    assert isrealnode(node)


### PR DESCRIPTION
@JanOdijk Dit fixed de bug zoals gerapporteerd door een Auris-medewerker.
Voor de problematische node, zie de toegevoegde test.
